### PR TITLE
Update to build 64-bit only on Xcode (macOS) with XPLM v3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ ipch
 *.sln
 *.sln.docstates
 .vs
+DerivedData
+.??*.swp

--- a/blu_fx.xcodeproj/project.pbxproj
+++ b/blu_fx.xcodeproj/project.pbxproj
@@ -7,12 +7,26 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AA15C19F22F2AB5900F8C3E8 /* mac.xpl in CopyFiles */ = {isa = PBXBuildFile; fileRef = D607B19909A556E400699BC3 /* mac.xpl */; };
 		D67297EB0F9E0FCC00CFD1FA /* blu_fx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D67297EA0F9E0FCC00CFD1FA /* blu_fx.cpp */; };
 		D6A7BDAA16A1DEA200D1426A /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A7BDA916A1DEA200D1426A /* OpenGL.framework */; };
 		D6A7BDC116A1DEC000D1426A /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A7BDC016A1DEC000D1426A /* CoreFoundation.framework */; };
 		D6A7BDF116A1DED200D1426A /* XPLM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A7BDF016A1DED200D1426A /* XPLM.framework */; };
 		D6A7BDF316A1DED200D1426A /* XPWidgets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A7BDF216A1DED200D1426A /* XPWidgets.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		AA15C19E22F2AB2B00F8C3E8 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(XPLANE_INSTALL_DIR)/Resources/plugins/$(PROJECT_NAME)/64";
+			dstSubfolderSpec = 0;
+			files = (
+				AA15C19F22F2AB5900F8C3E8 /* mac.xpl in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		D607B19909A556E400699BC3 /* mac.xpl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = mac.xpl; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,6 +97,7 @@
 			buildPhases = (
 				D607B19609A556E400699BC3 /* Sources */,
 				D607B19709A556E400699BC3 /* Frameworks */,
+				AA15C19E22F2AB2B00F8C3E8 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -136,7 +151,8 @@
 		D607B16309A5563100699BC3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				DYLIB_COMPATIBILITY_VERSION = "";
 				DYLIB_CURRENT_VERSION = "";
 				EXECUTABLE_EXTENSION = xpl;
@@ -146,6 +162,9 @@
 					"IBM=0",
 					"LIN=0",
 					"XPLM200=1",
+					"XPLM210=1",
+					"XPLM300=1",
+					"XPLM301=1",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GCC_VERSION = "";
@@ -155,23 +174,16 @@
 					"$(HEADER_SEARCH_PATHS)",
 				);
 				MACH_O_TYPE = mh_bundle;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
-				OTHER_LDFLAGS = (
-					"$(OTHER_LDFLAGS)",
-					"-Wl,-exported_symbol",
-					"-Wl,_XPluginStart",
-					"-Wl,-exported_symbol",
-					"-Wl,_XPluginEnable",
-					"-Wl,-exported_symbol",
-					"-Wl,_XPluginReceiveMessage",
-					"-Wl,-exported_symbol",
-					"-Wl,_XPluginDisable",
-					"-Wl,-exported_symbol",
-					"-Wl,_XPluginStop",
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-stdlib=libc++",
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = macosx;
+				USE_HEADERMAP = NO;
+				XPLANE_INSTALL_DIR = "/Users/brat/Desktop/X-Plane 11";
 				XPSDK_ROOT = SDK;
 			};
 			name = Debug;
@@ -179,7 +191,8 @@
 		D607B16409A5563100699BC3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				DYLIB_COMPATIBILITY_VERSION = "";
 				DYLIB_CURRENT_VERSION = "";
 				EXECUTABLE_EXTENSION = xpl;
@@ -189,6 +202,9 @@
 					"IBM=0",
 					"LIN=0",
 					"XPLM200=1",
+					"XPLM210=1",
+					"XPLM300=1",
+					"XPLM301=1",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GCC_VERSION = "";
@@ -198,23 +214,16 @@
 					"$(HEADER_SEARCH_PATHS)",
 				);
 				MACH_O_TYPE = mh_bundle;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
-				OTHER_LDFLAGS = (
-					"$(OTHER_LDFLAGS)",
-					"-Wl,-exported_symbol",
-					"-Wl,_XPluginStart",
-					"-Wl,-exported_symbol",
-					"-Wl,_XPluginEnable",
-					"-Wl,-exported_symbol",
-					"-Wl,_XPluginReceiveMessage",
-					"-Wl,-exported_symbol",
-					"-Wl,_XPluginDisable",
-					"-Wl,-exported_symbol",
-					"-Wl,_XPluginStop",
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-stdlib=libc++",
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = macosx;
+				USE_HEADERMAP = NO;
+				XPLANE_INSTALL_DIR = "/Users/brat/Desktop/X-Plane 11";
 				XPSDK_ROOT = SDK;
 			};
 			name = Release;

--- a/blu_fx.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
+++ b/blu_fx.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D607B19809A556E400699BC3"
+               BuildableName = "mac.xpl"
+               BlueprintName = "blu_fx"
+               ReferencedContainer = "container:blu_fx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D607B19809A556E400699BC3"
+            BuildableName = "mac.xpl"
+            BlueprintName = "blu_fx"
+            ReferencedContainer = "container:blu_fx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D607B19809A556E400699BC3"
+            BuildableName = "mac.xpl"
+            BlueprintName = "blu_fx"
+            ReferencedContainer = "container:blu_fx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/blu_fx.xcodeproj/xcshareddata/xcschemes/Release.xcscheme
+++ b/blu_fx.xcodeproj/xcshareddata/xcschemes/Release.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D607B19809A556E400699BC3"
+               BuildableName = "mac.xpl"
+               BlueprintName = "blu_fx"
+               ReferencedContainer = "container:blu_fx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D607B19809A556E400699BC3"
+            BuildableName = "mac.xpl"
+            BlueprintName = "blu_fx"
+            ReferencedContainer = "container:blu_fx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D607B19809A556E400699BC3"
+            BuildableName = "mac.xpl"
+            BlueprintName = "blu_fx"
+            ReferencedContainer = "container:blu_fx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Note: I only build and tested these changes on Xcode (for macOS target).  However, there are two types of changes:
(1) Mac-specific: Xcode project changes to build correctly for 64-bit with XPLM 3.1 based on previous updates; and
(2) All platforms: Usability improvements to add settings restore and explicit load/save buttons.

Therefore, these changes are tested and work great on macOS 10.14.6 (Mojave) with X-Plane 11.35r1 (August 1, 2019).  However, as I could not build (yet) for Windows, I have not yet tested anything there (nor Linux). So, there may be build issues, but I think it should be straightforward if not already working there. (So, I recommend testing it on those first of course).

Oh, and I also didn't test on a pre-XPLM3.1 system.  I believe my changes correctly switch from XPLMRegisterMenuItemIWthCommand() to XPLMRegisterMenuItem() -- but I'm not 100% sure.

-- Detailed changes in this pull request:

* Add new restore with explicit load/save buttons:
  - Provide users with a "restore" button that they can press any time to restore the loaded configuration.
  - Add explicit "load" and "save" buttons to allow users to control when the .ini file is saved. (Note: multiple files can be added later.)

* Add commandref to open settings window, and show key binding (if any) in menu.
  - Toggle the settings window open/close via commandref that proxies existing menu handler.

* Update Xcode project to correctly target XPLM 3.1 and 64-bit architecture.

* Fix up Xcode "schemes" so there is now a one-click way to switch btw Debug and Release builds, checked into repo in a common way (not user-specific).

* Notes:
  1. The settings are no longer auto-saved upon closing the settings window! Instead, there is one auto-save when the plugin is stopped. This is an important usability issue, since the new "save .ini" button implies it will only save if the user asks it to. (Though, saving on exit seems very reasonable, since "restore" and "load" are no longer relevant at that point, and people expect the state to persist.)
  2. The new "User" preset (connected to the "Restore" button) is *only* loaded at start-up, and never again. So, it represents the settings the user started X-Plane with (which will either be the .ini file, or the default settings if it's the first time). So, no matter how many times the user saves an update to the .ini file, "Restore" will always restore to the earlier setting! This is a feature. That is why there is a separate button,  "Load .ini", which explicitly updates the current settings from the saved file. However, loading does not overwrite the User preset, until the  plugin is re-loaded (usually by restarting X-Plane). The reason it works this way is as a foundation for the likely future option to save/restore multiple files. This will set things up nicely for that.
  3. For the Xcode project, there is an optional "copy" phase to auto-install the .xpl file into your X-Plane library. To get that to work, simply edit the project settings to define your XPLANE11_INSTALL_DIR path (i.s., the absolute path ending in .../X-Plane 11).

--

I hope this is useful! I know it helps me a lot to have these features. (And since macOS will block 32-bit libraries soon, having it updated to be 64-bit gives BLU-fx the new lease on life it deserves!

Thank you for making this open-source.

  Steve